### PR TITLE
Adds a requirement that operators must have exactly 1 BLS key

### DIFF
--- a/contracts/protocol/LagrangeCommittee.sol
+++ b/contracts/protocol/LagrangeCommittee.sol
@@ -88,6 +88,7 @@ contract LagrangeCommittee is BLSKeyChecker, Initializable, OwnableUpgradeable, 
 
     // Adds additional BLS public keys to an operator
     function addBlsPubKeys(address operator, BLSKeyWithProof calldata blsKeyWithProof) external onlyService {
+        revert("Not implemented");
         _validateBlsPubKeys(blsKeyWithProof.blsG1PublicKeys);
         _addBlsPubKeys(operator, blsKeyWithProof);
     }
@@ -586,7 +587,7 @@ contract LagrangeCommittee is BLSKeyChecker, Initializable, OwnableUpgradeable, 
     }
 
     function _validateBlsPubKeys(uint256[2][] memory _blsPubKeys) internal pure {
-        require(_blsPubKeys.length != 0, "Empty BLS Public Keys.");
+        require(_blsPubKeys.length == 1, "Exactly one BLS key is required per operator");
         uint256 _length = _blsPubKeys.length;
         for (uint256 i; i < _length; i++) {
             require(_blsPubKeys[i][0] != 0 && _blsPubKeys[i][1] != 0, "Invalid BLS Public Key.");

--- a/test/foundry/LagrangeDeployer.t.sol
+++ b/test/foundry/LagrangeDeployer.t.sol
@@ -413,11 +413,15 @@ contract LagrangeDeployer is Test {
 
         (uint256 startBlock,,, uint256 duration, uint256 freezeDuration,,,) = lagrangeCommittee.committeeParams(chainID);
         vm.roll(startBlock + duration - freezeDuration - 1);
-        lagrangeService.register(
-            operator,
-            _calcProofForBLSKeys(operator, blsPrivateKeys, bytes32("salt"), block.timestamp + 60),
-            operatorSignature
-        );
+
+        IBLSKeyChecker.BLSKeyWithProof memory proof =
+            _calcProofForBLSKeys(operator, blsPrivateKeys, bytes32("salt"), block.timestamp + 60);
+
+        if (blsPrivateKeys.length != 1) {
+            vm.expectRevert("Exactly one BLS key is required per operator");
+        }
+
+        lagrangeService.register(operator, proof, operatorSignature);
 
         lagrangeCommittee.getEpochNumber(chainID, block.number);
         lagrangeCommittee.isLocked(chainID);


### PR DESCRIPTION
This PR does the following:
* requires new operators have exactly 1 BLS key
* disables adding new BLS keys to existing operators
